### PR TITLE
new major version for GenericDeviceServer

### DIFF
--- a/doocs-generic-chimeratk-server/postinst
+++ b/doocs-generic-chimeratk-server/postinst
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+set -e
+
+case "$1" in
+    configure)
+        # continue as normal
+        ;;
+    abort-upgrade|abort-remove|abort-deconfigure)
+        exit 0;
+        ;;
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2;
+        exit 0;
+        ;;
+esac
+
+# check existence of /usr/bin/XXX-generic-chimeratk-serverYY to make sure we build tag of major version YY only with 
+# build-config for version YY and not later.
+# This can especially happen if you build the 01 generic-chimeratk-server with version latest; then we let validation step fail.
+if [ ! -f /usr/bin/doocs-generic-chimeratk-server ] ; then
+    echo "looks like you built wrong version of generic-chimeratk-server!"
+    echo "please build e.g. version 01 tags only with build config for version 01!"
+    exit 1
+fi

--- a/doocs-generic-chimeratk-server02/CONFIG
+++ b/doocs-generic-chimeratk-server02/CONFIG
@@ -1,0 +1,17 @@
+SourceURI: https://github.com/ChimeraTK/GenericDeviceServer.git
+Maintainer: Nadeem Shehzad <nadeem.shehzad@desy.de>
+Section: net
+License: lgpl3
+Target-repositories: intern pub
+
+Has-packages: bin
+Use-dynload: bin
+
+Package-name-bin: doocs-generic-chimeratk-server02
+
+Dependencies: libchimeratk-applicationcore-dev libchimeratk-controlsystemadapter-doocsadapter-dev
+Dependencies-bin: doocs-watchdog-server
+
+Override-auto-configure-flags: -DADAPTER=DOOCS
+
+Description-bin: ChimeraTK-based DOOCS server, to expose registers of any firmware directly to the control system.

--- a/doocs-generic-chimeratk-server02/postinst
+++ b/doocs-generic-chimeratk-server02/postinst
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+set -e
+
+case "$1" in
+    configure)
+        # continue as normal
+        ;;
+    abort-upgrade|abort-remove|abort-deconfigure)
+        exit 0;
+        ;;
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2;
+        exit 0;
+        ;;
+esac
+
+# check existence of /usr/bin/XXX-generic-chimeratk-serverYY to make sure we build tag of major version YY only with 
+# build-config for version YY and not later.
+# This can especially happen if you build the 01 generic-chimeratk-server with version latest; then we let validation step fail.
+if [ ! -f /usr/bin/doocs-generic-chimeratk-server02 ] ; then
+    echo "looks like you built wrong version of generic-chimeratk-server!"
+    echo "please build e.g. version 01 tags only with build config for version 01!"
+    exit 1
+fi

--- a/epics-generic-chimeratk-server/postinst
+++ b/epics-generic-chimeratk-server/postinst
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+set -e
+
+case "$1" in
+    configure)
+        # continue as normal
+        ;;
+    abort-upgrade|abort-remove|abort-deconfigure)
+        exit 0;
+        ;;
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2;
+        exit 0;
+        ;;
+esac
+
+# check existence of /usr/bin/XXX-generic-chimeratk-serverYY to make sure we build tag of major version YY only with 
+# build-config for version YY and not later.
+# This can especially happen if you build the 01 generic-chimeratk-server with version latest; then we let validation step fail.
+if [ ! -f /usr/bin/epics*-generic-chimeratk-server ] ; then
+    echo "looks like you built wrong version of generic-chimeratk-server!"
+    echo "please build e.g. version 01 tags only with build config for version 01!"
+    exit 1
+fi

--- a/epics-generic-chimeratk-server02/CONFIG
+++ b/epics-generic-chimeratk-server02/CONFIG
@@ -1,0 +1,16 @@
+SourceURI: https://github.com/ChimeraTK/GenericDeviceServer.git
+Maintainer: Nadeem Shehzad <nadeem.shehzad@desy.de>
+Section: net
+License: lgpl3
+Target-repositories: intern pub
+
+Has-packages: bin
+Use-dynload: bin
+
+Package-name-bin: epics-generic-chimeratk-server02
+
+Dependencies: libchimeratk-applicationcore-dev libchimeratk-controlsystemadapter-epics-ioc-adapter-dev
+
+Override-auto-configure-flags: -DADAPTER=EPICSIOC
+
+Description-bin: ChimeraTK-based EPICS server, to expose registers of any firmware directly to the control system.

--- a/epics-generic-chimeratk-server02/postinst
+++ b/epics-generic-chimeratk-server02/postinst
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+set -e
+
+case "$1" in
+    configure)
+        # continue as normal
+        ;;
+    abort-upgrade|abort-remove|abort-deconfigure)
+        exit 0;
+        ;;
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2;
+        exit 0;
+        ;;
+esac
+
+# check existence of /usr/bin/XXX-generic-chimeratk-serverYY to make sure we build tag of major version YY only with 
+# build-config for version YY and not later.
+# This can especially happen if you build the 01 generic-chimeratk-server with version latest; then we let validation step fail.
+if [ ! -f /usr/bin/epics*-generic-chimeratk-server02 ] ; then
+    echo "looks like you built wrong version of generic-chimeratk-server!"
+    echo "please build e.g. version 01 tags only with build config for version 01!"
+    exit 1
+fi

--- a/opcua-generic-chimeratk-server/postinst
+++ b/opcua-generic-chimeratk-server/postinst
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+set -e
+
+case "$1" in
+    configure)
+        # continue as normal
+        ;;
+    abort-upgrade|abort-remove|abort-deconfigure)
+        exit 0;
+        ;;
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2;
+        exit 0;
+        ;;
+esac
+
+# check existence of /usr/bin/XXX-generic-chimeratk-serverYY to make sure we build tag of major version YY only with 
+# build-config for version YY and not later.
+# This can especially happen if you build the 01 generic-chimeratk-server with version latest; then we let validation step fail.
+if [ ! -f /usr/bin/opcua-generic-chimeratk-server ] ; then
+    echo "looks like you built wrong version of generic-chimeratk-server!"
+    echo "please build e.g. version 01 tags only with build config for version 01!"
+    exit 1
+fi

--- a/opcua-generic-chimeratk-server02/CONFIG
+++ b/opcua-generic-chimeratk-server02/CONFIG
@@ -1,0 +1,16 @@
+SourceURI: https://github.com/ChimeraTK/GenericDeviceServer.git
+Maintainer: Nadeem Shehzad <nadeem.shehzad@desy.de>
+Section: net
+License: lgpl3
+Target-repositories: intern pub
+
+Has-packages: bin
+Use-dynload: bin
+
+Package-name-bin: opcua-generic-chimeratk-server02
+
+Dependencies: libchimeratk-applicationcore-dev libchimeratk-controlsystemadapter-opcuaadapter-dev
+
+Override-auto-configure-flags: -DADAPTER=OPCUA
+
+Description-bin: ChimeraTK-based OPC UA device server, to expose registers of any firmware directly to the control system.

--- a/opcua-generic-chimeratk-server02/postinst
+++ b/opcua-generic-chimeratk-server02/postinst
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+set -e
+
+case "$1" in
+    configure)
+        # continue as normal
+        ;;
+    abort-upgrade|abort-remove|abort-deconfigure)
+        exit 0;
+        ;;
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2;
+        exit 0;
+        ;;
+esac
+
+# check existence of /usr/bin/XXX-generic-chimeratk-serverYY to make sure we build tag of major version YY only with 
+# build-config for version YY and not later.
+# This can especially happen if you build the 01 generic-chimeratk-server with version latest; then we let validation step fail.
+if [ ! -f /usr/bin/opcua-generic-chimeratk-server02 ] ; then
+    echo "looks like you built wrong version of generic-chimeratk-server!"
+    echo "please build e.g. version 01 tags only with build config for version 01!"
+    exit 1
+fi

--- a/tango-generic-chimeratk-server/postinst
+++ b/tango-generic-chimeratk-server/postinst
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+set -e
+
+case "$1" in
+    configure)
+        # continue as normal
+        ;;
+    abort-upgrade|abort-remove|abort-deconfigure)
+        exit 0;
+        ;;
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2;
+        exit 0;
+        ;;
+esac
+
+# check existence of /usr/bin/XXX-generic-chimeratk-serverYY to make sure we build tag of major version YY only with 
+# build-config for version YY and not later.
+# This can especially happen if you build the 01 generic-chimeratk-server with version latest; then we let validation step fail.
+if [ ! -f /usr/bin/tango-generic-chimeratk-server ] ; then
+    echo "looks like you built wrong version of generic-chimeratk-server!"
+    echo "please build e.g. version 01 tags only with build config for version 01!"
+    exit 1
+fi

--- a/tango-generic-chimeratk-server02/CONFIG
+++ b/tango-generic-chimeratk-server02/CONFIG
@@ -1,0 +1,16 @@
+SourceURI: https://github.com/ChimeraTK/GenericDeviceServer.git
+Maintainer: Nadeem Shehzad <nadeem.shehzad@desy.de>
+Section: net
+License: lgpl3
+Target-repositories: intern pub
+
+Has-packages: bin
+Use-dynload: bin
+
+Package-name-bin: tango-generic-chimeratk-server02
+
+Dependencies: libchimeratk-applicationcore-dev libchimeratk-controlsystemadapter-tangoadapter-dev
+
+Override-auto-configure-flags: -DADAPTER=TANGO
+
+Description-bin: ChimeraTK-based Tango device server, to expose registers of any firmware directly to the control system.

--- a/tango-generic-chimeratk-server02/postinst
+++ b/tango-generic-chimeratk-server02/postinst
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+set -e
+
+case "$1" in
+    configure)
+        # continue as normal
+        ;;
+    abort-upgrade|abort-remove|abort-deconfigure)
+        exit 0;
+        ;;
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2;
+        exit 0;
+        ;;
+esac
+
+# check existence of /usr/bin/XXX-generic-chimeratk-serverYY to make sure we build tag of major version YY only with 
+# build-config for version YY and not later.
+# This can especially happen if you build the 01 generic-chimeratk-server with version latest; then we let validation step fail.
+if [ ! -f /usr/bin/tango-generic-chimeratk-server02 ] ; then
+    echo "looks like you built wrong version of generic-chimeratk-server!"
+    echo "please build e.g. version 01 tags only with build config for version 01!"
+    exit 1
+fi


### PR DESCRIPTION
we add new build configs for version 2 and keep entries for version 1 because we want reverse-dependency-search to maintain GenericDeviceServer for both versions (at least as long as we need a transition period)