### PR TITLE
fix: Depend on minimum GenericServer version if necessary.

### DIFF
--- a/doocs-interferometer-aquadb-generic-server/CONFIG
+++ b/doocs-interferometer-aquadb-generic-server/CONFIG
@@ -7,7 +7,7 @@ Target-repositories: intern
 Has-packages: extra
 
 Dependencies: config-generator-scripts
-Dependencies-extra: git, python3, python3-mako, config-generator-scripts#dependency-epochdashversion-config-generator-scripts#, doocs-generic-chimeratk-server02, doocs-watchdog-server, libchimeratk-deviceaccess-doocsbackend
+Dependencies-extra: git, python3, python3-mako, config-generator-scripts#dependency-epochdashversion-config-generator-scripts#, doocs-generic-chimeratk-server02 (>= 02.03), doocs-watchdog-server, libchimeratk-deviceaccess-doocsbackend
 
 Package-name-extra: doocs-interferometer-aquadb-generic-server#debversion#
 Override-auto-configure-flags: -DConfigGenerator_DIR=/usr/share/ConfigGenerator#dependency-epochversion-config-generator-scripts#

--- a/doocs-microtimer-server-config/CONFIG
+++ b/doocs-microtimer-server-config/CONFIG
@@ -7,7 +7,7 @@ Target-repositories: intern
 Has-packages: extra
 
 Dependencies: config-generator-scripts
-Dependencies-extra: git, python3, python3-mako, config-generator-scripts#dependency-epochdashversion-config-generator-scripts#, doocs-generic-chimeratk-server02, libchimeratk-deviceaccess-doocsbackend, doocs-watchdog-server
+Dependencies-extra: git, python3, python3-mako, config-generator-scripts#dependency-epochdashversion-config-generator-scripts#, doocs-generic-chimeratk-server02 (>= 02.03), libchimeratk-deviceaccess-doocsbackend, doocs-watchdog-server
 
 
 Package-name-extra: doocs-microtimer-server#debversion#


### PR DESCRIPTION
Generic Server configurations for the DOOCS adapter which require the DOOCS backend should not load the backend from the dmap file because the Generic Server now has it linked in. This requires at least GenericServer 02.03, so the configs
with the dynamic loading removed require this version.
